### PR TITLE
fix: refactoring tests pipeline

### DIFF
--- a/.devops/soaktest.yaml
+++ b/.devops/soaktest.yaml
@@ -34,12 +34,13 @@ parameters:
     displayName: "URL_BASE_PATH"
     type: string
     values:
-      - "https://api.uat.platform.pagopa.it/notifications-service"
+      - "https://api.dev.platform.pagopa.it"
+      - "https://api.uat.platform.pagopa.it"
   - name: "SCRIPT"
     displayName: "Script name"
     type: string
     values:
-      - soak-test
+      - soak-test-notifications
   # optional sub path where the project to be initialized is located. To be used on repository with multiple projects.
   - name: "projectDir"
     type: string

--- a/src/soak-test/soak-test-notifications.ts
+++ b/src/soak-test/soak-test-notifications.ts
@@ -42,7 +42,7 @@ export default function() {
     },
 };
 
-  let url = `${urlBasePath}/v1/emails`;
+  let url = `${urlBasePath}/notifications-service/v1/emails`;
   let res = http.post(url, JSON.stringify(bodyRequest), {
     ...headersParams,
     tags: { api: "notifications-test" },

--- a/src/soak-test/soak-test-transaction-auth.ts
+++ b/src/soak-test/soak-test-transaction-auth.ts
@@ -1,6 +1,6 @@
 import { check, fail, sleep } from "k6";
 import http from "k6/http";
-import { getConfigOrThrow } from "../utils/config.ts";
+import { getConfigOrThrow } from "../utils/config";
 
 const config = getConfigOrThrow();
 


### PR DESCRIPTION
Refactored test launcher pipeline to be used by multiple tests:

1. generalized pipeline base path so that can be shared across multiple tests
2. renamed notification test soak test file to avoid misleading selecting the test file

