### PR TITLE
Chk 773 load and soak test payment requests

### DIFF
--- a/.devops/soaktest.yaml
+++ b/.devops/soaktest.yaml
@@ -41,6 +41,8 @@ parameters:
     type: string
     values:
       - soak-test-notifications
+      - soak-test-carts
+      - soak-test-verifications
   # optional sub path where the project to be initialized is located. To be used on repository with multiple projects.
   - name: "projectDir"
     type: string

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 API_SUBSCRIPTION_KEY=NonEmptyString
-URL_BASE_PATH=localhost:8080
+URL_BASE_PATH=http://localhost:8080
 TEST_MAIL_FROM=NonEmptyString
 TEST_MAIL_TO=NonEmptyString
 

--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ $ docker run -i --rm -v $(pwd)/dist:/dist -e API_SUBSCRIPTION_KEY=${API_SUBSCRIP
 To run test and load env vars from `.env` file:
 
 ```
-$ docker run -i --rm -v $(pwd)/dist:/dist  --env-file .env loadimpact/k6 run /dist/soak-test-transaction-auth.js
+$ yarn webpack && docker run -i --rm -v $(pwd)/dist:/dist  --env-file .env loadimpact/k6 run /dist/soak-test-transaction-auth.js
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Let's keep in mind that before perform a load test you have to:
 This test require the dispatch of an email.
 
 ```
-$ docker run -i --rm -v $(pwd)/dist:/dist  -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test.js
+$ docker run -i --rm -v $(pwd)/dist:/dist  -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e PAYMENT_METHOD_NAME=${PAYMENT_METHOD_NAME} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test.js
 ```
 
 To run test and load env vars from `.env` file:
@@ -57,7 +57,7 @@ The following steps are performed for each test:
 2. GET /carts/{cartId} for retrieve the cart created at step 1 (taking cart id from POST response location header)
 
 ```
-$ docker run -i --rm -v $(pwd)/dist:/dist -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test-carts.js
+$ docker run -i --rm -v $(pwd)/dist:/dist -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e PAYMENT_METHOD_NAME=${PAYMENT_METHOD_NAME} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test-carts.js
 ```
 
 To run test and load env vars from `.env` file:
@@ -73,7 +73,7 @@ The following steps are performed for each test:
 1. GET /payment-requests/{rptId} for verify a payment notice status
 
 ```
-$ docker run -i --rm -v $(pwd)/dist:/dist -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test-verification.js
+$ docker run -i --rm -v $(pwd)/dist:/dist -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e PAYMENT_METHOD_NAME=${PAYMENT_METHOD_NAME} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test-verification.js
 ```
 
 To run test and load env vars from `.env` file:

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Let's keep in mind that before perform a load test you have to:
 This test require the dispatch of an email.
 
 ```
-$ docker run -i --rm -v $(pwd)/dist:/dist  -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test.js
+$ docker run -i --rm -v $(pwd)/dist:/dist  -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test-notifications.js
 ```
 
 To run test and load env vars from `.env` file:
 
 ```
-$ yarn webpack && docker run -i --rm -v $(pwd)/dist:/dist  --env-file .env loadimpact/k6 run /dist/soak-test.js
+$ yarn webpack && docker run -i --rm -v $(pwd)/dist:/dist  --env-file .env loadimpact/k6 run /dist/soak-test-notifications.js
 ```
 
 ## 02. Soak test - request transaction authorization
@@ -47,4 +47,37 @@ To run test and load env vars from `.env` file:
 
 ```
 $ yarn webpack && docker run -i --rm -v $(pwd)/dist:/dist  --env-file .env loadimpact/k6 run /dist/soak-test-transaction-auth.js
+```
+
+## 03. Soak test - carts
+
+This test perform a payment notices cart creation and retrieve
+The following steps are performed for each test:
+1. POST /carts for create a cart for a given payment notice
+2. GET /carts/{cartId} for retrieve the cart created at step 1 (taking cart id from POST response location header)
+
+```
+$ docker run -i --rm -v $(pwd)/dist:/dist -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test-carts.js
+```
+
+To run test and load env vars from `.env` file:
+
+```
+$ yarn webpack && docker run -i --rm -v $(pwd)/dist:/dist  --env-file .env loadimpact/k6 run /dist/soak-test-carts.js
+```
+
+## 04. Soak test - verification
+
+This test perform a payment notice verification request (for a given rptId)
+The following steps are performed for each test:
+1. GET /payment-requests/{rptId} for verify a payment notice status
+
+```
+$ docker run -i --rm -v $(pwd)/dist:/dist -e API_SUBSCRIPTION_KEY=${API_SUBSCRIPTION_KEY} -e URL_BASE_PATH=${URL_BASE_PATH} -e TEST_MAIL_FROM=${TEST_MAIL_FROM} -e TEST_MAIL_TO=${TEST_MAIL_TO} -e rate=${rate} -e duration=${duration} -e preAllocatedVUs=${preAllocatedVUs} -e maxVUs=${maxVUs} loadimpact/k6 run /dist/soak-test-verification.js
+```
+
+To run test and load env vars from `.env` file:
+
+```
+$ yarn webpack && docker run -i --rm -v $(pwd)/dist:/dist  --env-file .env loadimpact/k6 run /dist/soak-test-verification.js
 ```

--- a/src/soak-test/soak-test-carts.ts
+++ b/src/soak-test/soak-test-carts.ts
@@ -30,42 +30,42 @@ const headersParams = {
   redirects: 0,
 };
 
-const cartRequest =  {
+const cartRequest = {
   paymentNotices: [
-      {
-          noticeNumber: "302000100440009424",
-          fiscalCode: "77777777777",
-          amount: 10000,
-          companyName: "Test company",
-          description: "Payment notice description"
-      }
+    {
+      noticeNumber: "302000100440009424",
+      fiscalCode: "77777777777",
+      amount: 10000,
+      companyName: "Test company",
+      description: "Payment notice description"
+    }
   ],
   returnUrls: {
-      returnOkUrl: "https://returnOkUrl",
-      returnCancelUrl: "https://returnCancelUrl",
-      returnErrorUrl: "https://returnErrorUrl"
+    returnOkUrl: "https://returnOkUrl",
+    returnCancelUrl: "https://returnCancelUrl",
+    returnErrorUrl: "https://returnErrorUrl"
   },
   emailNotice: "test@test.it"
 }
 
-export default function() {
+export default function () {
   let url = `${urlBasePath}/checkout/ec/v1/carts`;
-  let res = http.post(url, 
+  let res = http.post(url,
     JSON.stringify(cartRequest),
-     {
-    ...headersParams,
-    tags: { api: "PostCarts" },
-  });
+    {
+      ...headersParams,
+      tags: { api: "PostCarts" },
+    });
   check(
     res,
     { "Response status from POST /carts was 302": (r) => r.status == 302 },
-    { api: "PostCarts" } 
+    { api: "PostCarts" }
   );
   let cartId;
-  if(res.status == 302){
+  if (res.status == 302) {
     cartId = res.headers["Location"];
     //take the cart id from the response header location value
-    cartId = cartId.substring(cartId.lastIndexOf('/')+1);
+    cartId = cartId.substring(cartId.lastIndexOf('/') + 1);
     url = `${urlBasePath}/checkout/ecommerce/v1/carts/${cartId}`;
     res = http.get(url, {
       ...headersParams,
@@ -74,11 +74,11 @@ export default function() {
     check(
       res,
       { "Response status from GET /carts was 200": (r) => r.status == 200 },
-      { api: "GetCarts"  }
+      { api: "GetCarts" }
     );
-  }else{
-    console.log("Post carts response code: "+res.status);
+  } else {
+    console.log("Post carts response code: " + res.status);
     fail("Invalid post carts response received");
   }
-  
+
 }

--- a/src/soak-test/soak-test-carts.ts
+++ b/src/soak-test/soak-test-carts.ts
@@ -1,0 +1,84 @@
+import { check, fail, sleep } from "k6";
+import http from "k6/http";
+import { getConfigOrThrow } from "../utils/config";
+
+const config = getConfigOrThrow();
+
+export let options = {
+  scenarios: {
+    contacts: {
+      executor: "constant-arrival-rate",
+      rate: config.rate, // e.g. 20000 for 20K iterations
+      duration: config.duration, // e.g. '1m'
+      preAllocatedVUs: config.preAllocatedVUs, // e.g. 500
+      maxVUs: config.maxVUs, // e.g. 1000
+    },
+  },
+  thresholds: {
+    "http_req_duration{api:PostCarts}": ["p(95)<1000"],//95% of post carts request must complete below 1.0s
+    "http_req_duration{api:GetCarts}": ["p(95)<1000"],//95% of get carts request must complete below 1.0s
+  },
+};
+
+
+const urlBasePath = config.URL_BASE_PATH;
+
+const headersParams = {
+  headers: {
+    "Content-Type": "application/json",
+  },
+  redirects: 0,
+};
+
+const cartRequest =  {
+  paymentNotices: [
+      {
+          noticeNumber: "302000100440009424",
+          fiscalCode: "77777777777",
+          amount: 10000,
+          companyName: "Test company",
+          description: "Payment notice description"
+      }
+  ],
+  returnUrls: {
+      returnOkUrl: "https://returnOkUrl",
+      returnCancelUrl: "https://returnCancelUrl",
+      returnErrorUrl: "https://returnErrorUrl"
+  },
+  emailNotice: "test@test.it"
+}
+
+export default function() {
+  let url = `${urlBasePath}/checkout/ec/v1/carts`;
+  let res = http.post(url, 
+    JSON.stringify(cartRequest),
+     {
+    ...headersParams,
+    tags: { api: "PostCarts" },
+  });
+  check(
+    res,
+    { "Response status from POST /carts was 302": (r) => r.status == 302 },
+    { api: "PostCarts" } 
+  );
+  let cartId;
+  if(res.status == 302){
+    cartId = res.headers["Location"];
+    //take the cart id from the response header location value
+    cartId = cartId.substring(cartId.lastIndexOf('/')+1);
+    url = `${urlBasePath}/checkout/ecommerce/v1/carts/${cartId}`;
+    res = http.get(url, {
+      ...headersParams,
+      tags: { api: "GetCarts" },
+    });
+    check(
+      res,
+      { "Response status from GET /carts was 200": (r) => r.status == 200 },
+      { api: "GetCarts"  }
+    );
+  }else{
+    console.log("Post carts response code: "+res.status);
+    fail("Invalid post carts response received");
+  }
+  
+}

--- a/src/soak-test/soak-test-notifications.ts
+++ b/src/soak-test/soak-test-notifications.ts
@@ -17,14 +17,14 @@ export let options = {
   thresholds: {
     http_req_duration: ["p(99)<1500"], // 99% of requests must complete below 1.5s
     checks: ['rate>0.9'], // 90% of the request must be completed
-    "http_req_duration{api:checkMessages}": ["p(95)<1000"],
+    "http_req_duration{api:notifications-test}": ["p(95)<1000"],
   },
 };
 
 
-export default function() {
+export default function () {
   const urlBasePath = config.URL_BASE_PATH;
-  const bodyRequest =  {
+  const bodyRequest = {
     to: config.TEST_MAIL_TO,
     subject: "test",
     templateId: "poc-1",
@@ -37,10 +37,10 @@ export default function() {
 
   const headersParams = {
     headers: {
-        'Content-Type': 'application/json',
-        'Ocp-Apim-Subscription-Key': config.API_SUBSCRIPTION_KEY
+      'Content-Type': 'application/json',
+      'Ocp-Apim-Subscription-Key': config.API_SUBSCRIPTION_KEY
     },
-};
+  };
 
   let url = `${urlBasePath}/notifications-service/v1/emails`;
   let res = http.post(url, JSON.stringify(bodyRequest), {
@@ -51,7 +51,7 @@ export default function() {
   check(
     res,
     { "Response status from POST /emails was 200": (r) => r.status == 200 },
-    { tags: { api: "notifications-test" } }
+    { api: "notifications-test"  }
   );
-  
+
 }

--- a/src/soak-test/soak-test-transaction-auth.ts
+++ b/src/soak-test/soak-test-transaction-auth.ts
@@ -41,7 +41,7 @@ export default function () {
     var emailAddress = config.TEST_MAIL_TO
     // Get Payment Request Info NM3
     response = http.get(
-        `https://${urlBasePath}/checkout/ecommerce/v1/payment-requests/${rptId}?recaptchaResponse=test`
+        `${urlBasePath}/checkout/ecommerce/v1/payment-requests/${rptId}?recaptchaResponse=test`
     )
     check(response, {
         'Response status from GET /payment-requests is 200': (r) => r.status == 200,
@@ -61,7 +61,7 @@ export default function () {
         }
 
         response = http.post(
-            `https://${urlBasePath}/checkout/ecommerce/v1/transactions?test=debug`,
+            `${urlBasePath}/checkout/ecommerce/v1/transactions?test=debug`,
             JSON.stringify(bodyRequest),
             {
                 headers: {
@@ -82,7 +82,7 @@ export default function () {
     if (transactionId !== undefined) {
         // Get transaction
         response = http.get(
-            `https://${urlBasePath}/checkout/ecommerce/v1/transactions/${transactionId}`
+            `${urlBasePath}/checkout/ecommerce/v1/transactions/${transactionId}`
         )
         check(response, {
             'Response status from GET /transactions is 200': (r) => r.status == 200,
@@ -97,7 +97,7 @@ export default function () {
     // Get payment methods
     if (amount !== undefined) {
         response = http.get(
-            `https://${urlBasePath}/checkout/ecommerce/v1/payment-methods?amount=${amount}`
+            `${urlBasePath}/checkout/ecommerce/v1/payment-methods?amount=${amount}`
         )
         check(response, {
             'Response status from GET /payment-methods is 200': (r) => r.status == 200,
@@ -111,7 +111,7 @@ export default function () {
     // Get PSPs by payment method
     if (paymentMethodId !== undefined && amount !== undefined) {
         response = http.get(
-            `https://${urlBasePath}/checkout/ecommerce/v1/payment-methods/${paymentMethodId}/psps?amount=${amount}`
+            `${urlBasePath}/checkout/ecommerce/v1/payment-methods/${paymentMethodId}/psps?amount=${amount}`
         )
         check(response, {
             'Response status from GET /payment-methods is 200': (r) => r.status == 200,
@@ -132,7 +132,7 @@ export default function () {
             "language": "IT"
         }
         response = http.post(
-            `https://${urlBasePath}/checkout/ecommerce/v1/transactions/${transactionId}/auth-requests`,
+            `${urlBasePath}/checkout/ecommerce/v1/transactions/${transactionId}/auth-requests`,
             JSON.stringify(bodyRequest),
             {
                 headers: {

--- a/src/soak-test/soak-test-verification.ts
+++ b/src/soak-test/soak-test-verification.ts
@@ -4,46 +4,80 @@ import { getConfigOrThrow } from "../utils/config";
 
 const config = getConfigOrThrow();
 
-function generateRptId() {
-  var result = '77777777777302001';
-  for (var i = 0; i < 12; i++) {
-    result = result.concat((Math.floor(Math.random() * 10)).toString());
-  }
-  return result;
-}
 export let options = {
   scenarios: {
-    contacts: {
+    hitCacheNm3: {
       executor: "constant-arrival-rate",
       rate: config.rate, // e.g. 20000 for 20K iterations
       duration: config.duration, // e.g. '1m'
       preAllocatedVUs: config.preAllocatedVUs, // e.g. 500
       maxVUs: config.maxVUs, // e.g. 1000
+      exec: "hitCacheNm3"
+    },
+    hitCache: {
+      executor: "constant-arrival-rate",
+      rate: config.rate, // e.g. 20000 for 20K iterations
+      duration: config.duration, // e.g. '1m'
+      preAllocatedVUs: config.preAllocatedVUs, // e.g. 500
+      maxVUs: config.maxVUs, // e.g. 1000
+      exec: "hitCache"
     },
   },
   thresholds: {
-    "http_req_duration{api:PaymentRequest-verify}": ["p(95)<1000"],//95% of post carts request must complete below 1.0s
+    "http_req_duration{api:PaymentRequest-verify-NM3}": ["p(95)<1000"],//95% of requests must complete below 1.0s
+    "http_req_duration{api:PaymentRequest-verify-NM3-hitCache}": ["p(95)<1000"],//95% of requests must complete below 1.0s
+    "http_req_duration{api:PaymentRequest-verify}": ["p(95)<1000"],//95% of requests must complete below 1.0s
+    "http_req_duration{api:PaymentRequest-verify-hitCache}": ["p(95)<1000"],//95% of requests must complete below 1.0s
   },
 };
 
-
 const urlBasePath = config.URL_BASE_PATH;
 
+function generateRandomRptId(nm3:Boolean) {
+  var type = nm3?'3':'2';
+  var result = `77777777777${type}02001`;
+  for (var i = 0; i < 12; i++) {
+    result = result.concat((Math.floor(Math.random() * 10)).toString());
+  }
+  return result;
+}
 
-export default function () {
-    var rptId = generateRptId();
-    rptId = '77777777777211111111112222222';
+export function hitCache(){
+  hitCacheTest(false);
+}
+
+export function hitCacheNm3(){
+  hitCacheTest(true);
+}
+
+
+export function hitCacheTest(nm3:Boolean) {
+    // Generate a new random rptId
+    var rptId = generateRandomRptId(nm3);
+    const tagPrefix = nm3?'PaymentRequest-verify-NM3':'PaymentRequest-verify';
     let url = `${urlBasePath}/checkout/ecommerce/v1/payment-requests/${rptId}?recaptchaResponse=test`;
     // Get Payment Request Info NM3
     let response = http.get(
         url,
         {
-          tags: { api: "PaymentRequest-verify" },
+          tags: { api: tagPrefix },
         }
     );
     check(
       response,
       { "Response status from GET /payment-request was 200": (r) => r.status == 200 },
-      { api: "PaymentRequest-verify" }
+      { api: tagPrefix }
     );
+    //make a verify request for the same rptId to test cache hit response time
+    response = http.get(
+      url,
+      {
+        tags: { api: `${tagPrefix}-hitCache` },
+      }
+  );
+  check(
+    response,
+    { "Response status from GET /payment-request was 200": (r) => r.status == 200 },
+    { api: `${tagPrefix}-hitCache` }
+  );
   }

--- a/src/soak-test/soak-test-verification.ts
+++ b/src/soak-test/soak-test-verification.ts
@@ -1,0 +1,49 @@
+import { check, fail, sleep } from "k6";
+import http from "k6/http";
+import { getConfigOrThrow } from "../utils/config";
+
+const config = getConfigOrThrow();
+
+function generateRptId() {
+  var result = '77777777777302001';
+  for (var i = 0; i < 12; i++) {
+    result = result.concat((Math.floor(Math.random() * 10)).toString());
+  }
+  return result;
+}
+export let options = {
+  scenarios: {
+    contacts: {
+      executor: "constant-arrival-rate",
+      rate: config.rate, // e.g. 20000 for 20K iterations
+      duration: config.duration, // e.g. '1m'
+      preAllocatedVUs: config.preAllocatedVUs, // e.g. 500
+      maxVUs: config.maxVUs, // e.g. 1000
+    },
+  },
+  thresholds: {
+    "http_req_duration{api:PaymentRequest-verify}": ["p(95)<1000"],//95% of post carts request must complete below 1.0s
+  },
+};
+
+
+const urlBasePath = config.URL_BASE_PATH;
+
+
+export default function () {
+    var rptId = generateRptId();
+    rptId = '77777777777211111111112222222';
+    let url = `${urlBasePath}/checkout/ecommerce/v1/payment-requests/${rptId}?recaptchaResponse=test`;
+    // Get Payment Request Info NM3
+    let response = http.get(
+        url,
+        {
+          tags: { api: "PaymentRequest-verify" },
+        }
+    );
+    check(
+      response,
+      { "Response status from GET /payment-request was 200": (r) => r.status == 200 },
+      { api: "PaymentRequest-verify" }
+    );
+  }


### PR DESCRIPTION
Below a list of the changes:

1. Add soak tests for ecommerce-payment-requests module:

- Tests for carts API (POST and GET cart)
- Tests for payment notice verify (GET payment-requests/{rptId}

2. Minor fixes to notifications test: fix K6 check method tags
3. Add unique tag to each transaction-auth request and check so that statistics are extracted indipendently for each request
