### PR TITLE
chore: use open model thread group for ramping arrival test

### DIFF
--- a/JMeter/Soak Test Ecommerce For Checkout.jmx
+++ b/JMeter/Soak Test Ecommerce For Checkout.jmx
@@ -21,10 +21,12 @@
           </elementProp>
         </collectionProp>
       </elementProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
     </TestPlan>
     <hashTree>
       <OpenModelThreadGroup guiclass="OpenModelThreadGroupGui" testclass="OpenModelThreadGroup" testname="Open Model Thread Group">
-        <stringProp name="OpenModelThreadGroup.schedule">rate(0/sec) random_arrivals(15 min) rate(30/sec) random_arrivals(60 min) rate(30/sec)</stringProp>
+        <stringProp name="OpenModelThreadGroup.schedule">rate(0/sec) random_arrivals(15 min) rate(5/sec) random_arrivals(60 min) rate(5/sec)</stringProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="OpenModelThreadGroupController"/>
       </OpenModelThreadGroup>
@@ -201,7 +203,7 @@ vars.put(&apos;RPT_ID&apos;, rpt)
 log.info(&quot;RPT_ID: &quot; + rpt);</stringProp>
           </JSR223PreProcessor>
           <hashTree/>
-          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
             <collectionProp name="HeaderManager.headers">
               <elementProp name="" elementType="Header">
                 <stringProp name="Header.name">tags</stringProp>
@@ -215,7 +217,7 @@ log.info(&quot;RPT_ID: &quot; + rpt);</stringProp>
           </HeaderManager>
           <hashTree/>
         </hashTree>
-        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If PAYMENT_METHOD == CARDS">
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If PAYMENT_METHOD == CARDS" enabled="true">
           <stringProp name="IfController.condition">${__groovy(
   def pm = vars.get(&apos;PAYMENT_METHOD&apos;);
   pm == &apos;CARDS&apos;
@@ -265,7 +267,7 @@ log.info(&quot;RPT_ID: &quot; + rpt);</stringProp>
             <hashTree/>
           </hashTree>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Activate Transaction">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Activate Transaction" enabled="true">
           <stringProp name="HTTPSampler.path">${BASE_PATH_V2}/transactions?recaptchaResponse=test</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
@@ -364,7 +366,7 @@ log.info(&quot;IS_ALL_CCP: &quot; + isAll);</stringProp>
           </JSR223PostProcessor>
           <hashTree/>
         </hashTree>
-        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If PAYMENT_METHOD == CARDS">
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If PAYMENT_METHOD == CARDS" enabled="true">
           <stringProp name="IfController.condition">${__groovy(
   def pm = vars.get(&apos;PAYMENT_METHOD&apos;);
   pm == &apos;CARDS&apos;
@@ -373,7 +375,7 @@ log.info(&quot;IS_ALL_CCP: &quot; + isAll);</stringProp>
           <boolProp name="IfController.useExpression">true</boolProp>
         </IfController>
         <hashTree>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[GET] Session (CARDS)">
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[GET] Session (CARDS)" enabled="true">
             <stringProp name="HTTPSampler.path">${BASE_PATH_V1}/payment-methods/${PAYMENT_METHOD_ID}/sessions/${ORDER_ID}</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -399,7 +401,7 @@ log.info(&quot;IS_ALL_CCP: &quot; + isAll);</stringProp>
             <hashTree/>
           </hashTree>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Calculate Fees">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Calculate Fees" enabled="true">
           <stringProp name="HTTPSampler.path">${BASE_PATH_V2}/payment-methods/${PAYMENT_METHOD_ID}/fees?maxOccurences=1235</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
@@ -459,7 +461,7 @@ log.info(&quot;IS_ALL_CCP: &quot; + isAll);</stringProp>
           </JSONPostProcessor>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Request Authorization Transaction">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Request Authorization Transaction" enabled="true">
           <stringProp name="HTTPSampler.path">${BASE_PATH_V1}/transactions/${TRANSACTION_ID}/auth-requests</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
@@ -571,7 +573,7 @@ log.info(&quot;AUTH_REQUEST_JSON: &quot; + JsonOutput.prettyPrint(jsonBody));
           </HeaderManager>
           <hashTree/>
         </hashTree>
-        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Pool Outcomes (x5)">
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Pool Outcomes (x5)" enabled="true">
           <stringProp name="LoopController.loops">5</stringProp>
         </LoopController>
         <hashTree>
@@ -606,7 +608,7 @@ log.info(&quot;AUTH_REQUEST_JSON: &quot; + JsonOutput.prettyPrint(jsonBody));
           <hashTree/>
         </hashTree>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/JMeter/Soak Test Ecommerce For Checkout.jmx
+++ b/JMeter/Soak Test Ecommerce For Checkout.jmx
@@ -21,24 +21,15 @@
           </elementProp>
         </collectionProp>
       </elementProp>
-      <boolProp name="TestPlan.functional_mode">false</boolProp>
-      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
     </TestPlan>
     <hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group">
-        <intProp name="ThreadGroup.num_threads">17</intProp>
-        <intProp name="ThreadGroup.ramp_time">600</intProp>
-        <longProp name="ThreadGroup.duration">3600</longProp>
-        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
-        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+      <OpenModelThreadGroup guiclass="OpenModelThreadGroupGui" testclass="OpenModelThreadGroup" testname="Open Model Thread Group">
+        <stringProp name="OpenModelThreadGroup.schedule">rate(0/sec) random_arrivals(15 min) rate(30/sec) random_arrivals(60 min) rate(30/sec)</stringProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
-        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
-          <intProp name="LoopController.loops">-1</intProp>
-          <boolProp name="LoopController.continue_forever">false</boolProp>
-        </elementProp>
-      </ThreadGroup>
+        <elementProp name="ThreadGroup.main_controller" elementType="OpenModelThreadGroupController"/>
+      </OpenModelThreadGroup>
       <hashTree>
-        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="JSR223 PreProcessor for Header" enabled="true">
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="JSR223 PreProcessor for Header">
           <stringProp name="cacheKey">true</stringProp>
           <stringProp name="filename"></stringProp>
           <stringProp name="parameters"></stringProp>
@@ -143,7 +134,7 @@ if (vars.get(&apos;PAYMENT_METHOD&apos;) == null &amp;&amp; vars.get(&apos;PAYME
           <stringProp name="scriptLanguage">groovy</stringProp>
         </JSR223PreProcessor>
         <hashTree/>
-        <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
+        <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults">
           <stringProp name="HTTPSampler.domain">${URL_BASE_PATH}</stringProp>
           <stringProp name="HTTPSampler.port">443</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
@@ -153,7 +144,7 @@ if (vars.get(&apos;PAYMENT_METHOD&apos;) == null &amp;&amp; vars.get(&apos;PAYME
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
         </ConfigTestElement>
         <hashTree/>
-        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
           <collectionProp name="HeaderManager.headers">
             <elementProp name="" elementType="Header">
               <stringProp name="Header.name">Content-Type</stringProp>
@@ -178,7 +169,7 @@ if (vars.get(&apos;PAYMENT_METHOD&apos;) == null &amp;&amp; vars.get(&apos;PAYME
           </collectionProp>
         </HeaderManager>
         <hashTree/>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[GET] Verify Payment Notice" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[GET] Verify Payment Notice">
           <stringProp name="HTTPSampler.path">${BASE_PATH_V1}/payment-requests/${RPT_ID}</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -197,7 +188,7 @@ if (vars.get(&apos;PAYMENT_METHOD&apos;) == null &amp;&amp; vars.get(&apos;PAYME
           </elementProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="JSR223 PreProcessor" enabled="true">
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="JSR223 PreProcessor">
             <stringProp name="scriptLanguage">groovy</stringProp>
             <stringProp name="parameters"></stringProp>
             <stringProp name="filename"></stringProp>
@@ -210,7 +201,7 @@ vars.put(&apos;RPT_ID&apos;, rpt)
 log.info(&quot;RPT_ID: &quot; + rpt);</stringProp>
           </JSR223PreProcessor>
           <hashTree/>
-          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
             <collectionProp name="HeaderManager.headers">
               <elementProp name="" elementType="Header">
                 <stringProp name="Header.name">tags</stringProp>
@@ -224,7 +215,7 @@ log.info(&quot;RPT_ID: &quot; + rpt);</stringProp>
           </HeaderManager>
           <hashTree/>
         </hashTree>
-        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If PAYMENT_METHOD == CARDS" enabled="true">
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If PAYMENT_METHOD == CARDS">
           <stringProp name="IfController.condition">${__groovy(
   def pm = vars.get(&apos;PAYMENT_METHOD&apos;);
   pm == &apos;CARDS&apos;
@@ -274,7 +265,7 @@ log.info(&quot;RPT_ID: &quot; + rpt);</stringProp>
             <hashTree/>
           </hashTree>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Activate Transaction" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Activate Transaction">
           <stringProp name="HTTPSampler.path">${BASE_PATH_V2}/transactions?recaptchaResponse=test</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
@@ -373,7 +364,7 @@ log.info(&quot;IS_ALL_CCP: &quot; + isAll);</stringProp>
           </JSR223PostProcessor>
           <hashTree/>
         </hashTree>
-        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If PAYMENT_METHOD == CARDS" enabled="true">
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If PAYMENT_METHOD == CARDS">
           <stringProp name="IfController.condition">${__groovy(
   def pm = vars.get(&apos;PAYMENT_METHOD&apos;);
   pm == &apos;CARDS&apos;
@@ -382,7 +373,7 @@ log.info(&quot;IS_ALL_CCP: &quot; + isAll);</stringProp>
           <boolProp name="IfController.useExpression">true</boolProp>
         </IfController>
         <hashTree>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[GET] Session (CARDS)" enabled="true">
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[GET] Session (CARDS)">
             <stringProp name="HTTPSampler.path">${BASE_PATH_V1}/payment-methods/${PAYMENT_METHOD_ID}/sessions/${ORDER_ID}</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -408,7 +399,7 @@ log.info(&quot;IS_ALL_CCP: &quot; + isAll);</stringProp>
             <hashTree/>
           </hashTree>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Calculate Fees" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Calculate Fees">
           <stringProp name="HTTPSampler.path">${BASE_PATH_V2}/payment-methods/${PAYMENT_METHOD_ID}/fees?maxOccurences=1235</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
@@ -468,7 +459,7 @@ log.info(&quot;IS_ALL_CCP: &quot; + isAll);</stringProp>
           </JSONPostProcessor>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Request Authorization Transaction" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[POST] Request Authorization Transaction">
           <stringProp name="HTTPSampler.path">${BASE_PATH_V1}/transactions/${TRANSACTION_ID}/auth-requests</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
@@ -580,7 +571,7 @@ log.info(&quot;AUTH_REQUEST_JSON: &quot; + JsonOutput.prettyPrint(jsonBody));
           </HeaderManager>
           <hashTree/>
         </hashTree>
-        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Pool Outcomes (x5)" enabled="true">
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Pool Outcomes (x5)">
           <stringProp name="LoopController.loops">5</stringProp>
         </LoopController>
         <hashTree>
@@ -615,7 +606,7 @@ log.info(&quot;AUTH_REQUEST_JSON: &quot; + JsonOutput.prettyPrint(jsonBody));
           <hashTree/>
         </hashTree>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/JMeter/Soak Test Ecommerce For Checkout.jmx
+++ b/JMeter/Soak Test Ecommerce For Checkout.jmx
@@ -26,7 +26,7 @@
     </TestPlan>
     <hashTree>
       <OpenModelThreadGroup guiclass="OpenModelThreadGroupGui" testclass="OpenModelThreadGroup" testname="Open Model Thread Group">
-        <stringProp name="OpenModelThreadGroup.schedule">rate(0/sec) random_arrivals(15 min) rate(5/sec) random_arrivals(60 min) rate(5/sec)</stringProp>
+        <stringProp name="OpenModelThreadGroup.schedule">rate(0/sec) random_arrivals(5 min) rate(5/sec) random_arrivals(60 min) rate(5/sec)</stringProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="OpenModelThreadGroupController"/>
       </OpenModelThreadGroup>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Use ramping arrival rate thread model in place of thread group control since ramping up model is more precise and easily configurable (ramp up specified with duration, f.e. 
`rate(0/sec) random_arrivals(10 min) rate(30/sec) random_arrivals(60 min) rate(30/sec)`

allowing for ramp up / ramp down, hills and more complex traffic shape scenarios
<!--- Describe your changes in detail -->

#### Motivation and Context
This model allow to perform tests with a ramping arrival rate where traffic can start from zero linearly increasing up to the target value
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.